### PR TITLE
Added moment node module to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "attributes"
   ],
   "dependencies": {
-    "lodash": "^4.4.0",
+    "bluebird": "^3.0.0",
     "html-form-generator": "^1.2.0",
-    "bluebird": "^3.0.0"
+    "lodash": "^4.4.0",
+    "moment": "^2.18.1"
   },
   "author": "Gregory Kapustin",
   "license": "ISC",


### PR DESCRIPTION
Moment node module was not being included inside of the module.
`sails-html-form-generator/lib/models.js` line 2 required this module but was not included in the package